### PR TITLE
feat: Require keycard for moneywash entry

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -90,9 +90,16 @@ RegisterNetEvent('fz-moneywash:openWashingMachine', function(id)
     lib.showContext('washingmachine_' .. id)
 end)
 
-local function enterMoneywash(moneywash, coords)
+local function enterMoneywash(moneywash, coords, requireCard)
     local playerPed = PlayerPedId()
     if moneywash == "entrance" then 
+        if requireCard then
+            local checkCard = lib.callback.await('fz-moneywash:checkMoneywashCard', false)
+            if not checkCard then
+                TriggerEvent('fz-moneywash:notify', locale('error.no_moneywash_card'), 'error')
+                return
+            end
+        end
         TriggerEvent('fz-moneywash:notify', locale('info.entering_moneywash'), 'info')
     elseif moneywash == "exit" then
         TriggerEvent('fz-moneywash:notify', locale('info.exiting_moneywash'), 'info')
@@ -111,6 +118,7 @@ local function setupEnterAndExitMoneywash()
     for i, current in pairs (config.moneywashes) do
         local entranceCoords = current.entrance
         local exitCoords = current.exit
+        local requireCard = current.requireCard
         if config.useTarget then
             exports.ox_target:addBoxZone({
                 coords = entranceCoords.xyz,
@@ -123,7 +131,7 @@ local function setupEnterAndExitMoneywash()
                         label = locale('moneywash.target_enter'),
                         icon = 'fas fa-door-open',
                         onSelect = function()
-                            enterMoneywash("entrance", exitCoords)
+                            enterMoneywash("entrance", exitCoords, requireCard)
                         end,
                     },
                 },
@@ -139,7 +147,7 @@ local function setupEnterAndExitMoneywash()
                         label = locale('moneywash.target_exit'),
                         icon = 'fas fa-door-open',
                         onSelect = function()
-                            enterMoneywash("exit", entranceCoords)
+                            enterMoneywash("exit", entranceCoords, requireCard)
                         end,
                     },
                 },

--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,7 @@ Config.debug = false -- Use debug for the box and poly zones.
 Config.useTarget = true -- Use ox_target or  TextUi for interaction.
 Config.keybind = 38 -- Control index for the TextUI. Default is 'E' (38) Change locals file for UI text. https://docs.fivem.net/docs/game-references/controls/#controls
 
+Config.moneywashCard = 'moneywash_card' -- Moneywash keycard item name.
 Config.dirtycashItem = 'black_money' -- Dirty cash item name.
 Config.tax = 0.2 -- Tax on washing money also applies to stopping the wash, 0.2 by default being 20%.
 
@@ -14,6 +15,7 @@ Config.maxwashtime = 15 -- Maximum washing time in minutes.
 
 Config.moneywashes = {
     moneywash1 = {
+        requireCard = true, -- If true, player needs a moneywash keycard to enter the moneywash.
         entrance = vec4(636.46, 2786.18, 42.21, 2.56),
         exit = vec4(1138.09, -3199.13, -39.67, 185.48),
         washingmachines = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,8 @@
         "already_using_machine": "You can only use one washing machine at a time.",
         "not_enough_inventory_space": "You don't have enough space in your inventory to collect.",
         "invalid_moneywash": "Door is locked.",
-        "missing_items": "You don't have the correct amount of dirty cash on you."
+        "missing_items": "You don't have the correct amount of dirty cash on you.",
+        "no_moneywash_card": "You need a keycard to enter."
     },
     "success": {
         "money_washed": "Your money has been laundered.",

--- a/server/main.lua
+++ b/server/main.lua
@@ -37,6 +37,16 @@ local function GetPlayer(source)
     end
 end
 
+lib.callback.register('fz-moneywash:checkMoneywashCard', function(source)
+    if not config.moneywashCard then return true end
+    local cardAmount = exports.ox_inventory:GetItem(source, config.moneywashCard, nil, true)
+    if cardAmount and cardAmount > 0 then
+        return true
+    else
+        return false
+    end
+end)
+
 lib.callback.register('fz-moneywash:getMoney', function(source)
     local moneyAmount = exports.ox_inventory:GetItem(source, config.dirtycashItem, nil, true)
     return moneyAmount


### PR DESCRIPTION
Added a keycard requirement for entering moneywash locations. Updated config to specify the keycard item, added server-side check for possession, and improved client logic and localization to notify players if they lack the required keycard.